### PR TITLE
fatal error when running w/ php 5.4

### DIFF
--- a/www/camera.php
+++ b/www/camera.php
@@ -82,21 +82,21 @@ function writeToFile($file, $content){
      if ($latLon[0] > 0 && $latLon[1] < $divHCount - 1) {
        if ($latLon[0] > 0) {
          $posNeigh = ($latLon[0] - 1) . ',' . ($latLon[1] + 1);
-         mergeNeighbor(&$clusterGrid, $pos, $posNeigh);
+         mergeNeighbor($clusterGrid, $pos, $posNeigh);
        }
 
        $posNeigh = $latLon[0] . ',' . ($latLon[1] + 1);
-       mergeNeighbor(&$clusterGrid, $pos, $posNeigh);
+       mergeNeighbor($clusterGrid, $pos, $posNeigh);
 
        if ($latLon[0] < $divWCount - 1) {
          $posNeigh = ($latLon[0] + 1) . ',' . ($latLon[1] + 1);
-         mergeNeighbor(&$clusterGrid, $pos, $posNeigh);
+         mergeNeighbor($clusterGrid, $pos, $posNeigh);
        }
      } 
 
      if ($latLon[0] < $divWCount - 1) {
        $posNeigh = ($latLon[0] + 1) . ',' . $latLon[1];
-       mergeNeighbor(&$clusterGrid, $pos, $posNeigh);
+       mergeNeighbor($clusterGrid, $pos, $posNeigh);
      } 
    }
 


### PR DESCRIPTION
In php 5.4 call-time pass-by-reference was deprecated, causing a fatal error when running camera.php
http://php.net/manual/en/language.references.pass.php
